### PR TITLE
Dev VM, Terraform container, fix timeout

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,85 @@
+# curl -L https://github.com/docker/compose/releases/download/1.17.0/docker-compose-`uname -s`-`uname -m` -o /usr/bin/docker-compose
+Vagrant.configure("2") do |config|
+  common_config = ->(config) do
+    config.vm.hostname="vagrant"
+    config.vm.box = "ubuntu/trusty64"
+    config.vm.box_check_update = false
+    config.vbguest.auto_update = false
+
+    config.vm.synced_folder ".", "/mnt/vagrant"
+
+    config.vm.provider "virtualbox" do |v|
+      v.customize ["modifyvm", :id, "--cpuexecutioncap", "100"]
+      v.customize ["modifyvm", :id, "--memory", "1024"]
+    end
+  end
+
+  forward_port = ->(guest, host = guest) do
+    config.vm.network :forwarded_port,
+      guest: guest,
+      host: host,
+      auto_correct: true
+  end
+
+  fix_tty = ->(config) do
+    config.vm.provision "fix-no-tty", type: "shell" do |s|
+      s.privileged = false
+      s.inline = "sudo sed -i '/tty/!s/mesg n/tty -s \\&\\& mesg n/' /root/.profile"
+    end
+  end
+
+  install_common = ->(config) do
+    config.vm.provision "shell", inline: <<-SHELL
+      apt-get -y install git tree
+    SHELL
+  end
+
+  install_docker = ->(config) do
+    config.vm.provision "shell", inline: <<-SHELL
+      apt-get update && sudo apt-get install -y apt-transport-https ca-certificates curl software-properties-common
+      curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+      apt-key fingerprint 0EBFCD88 | grep docker@docker.com || exit 1
+      add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+      apt-get update
+      apt-get install -y docker-ce
+      docker --version
+    SHELL
+  end
+
+  pull_docker_images = ->(config) do
+    config.vm.provision "shell", inline: <<-SHELL
+      docker pull hashicorp/terraform:light
+    SHELL
+  end
+
+  install_node = ->(config) do
+    config.vm.provision "shell", inline: <<-SHELL
+      curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
+      apt-get install -y nodejs
+      npm i -g yarn
+    SHELL
+  end
+
+  install_devbox = ->(config) do
+    config.vm.provision "shell", privileged: false, inline: <<-SHELL
+      cd /mnt/vagrant && yarn install
+    SHELL
+  end
+
+  install_terraform = ->(config) do
+    config.vm.provision "shell", inline: <<-SHELL
+      cp /mnt/vagrant/bin/terraform /usr/bin/.
+    SHELL
+  end
+
+  config.vm.define "devbox" do |devbox|
+    common_config[devbox]
+    forward_port[8080]
+
+    fix_tty[devbox]
+    install_common[devbox]
+    install_node[devbox]
+    install_docker[devbox]
+    pull_docker_images[devbox]
+  end
+end

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "dynamic-dockerizer-master",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Master component of Dynamic Dockerizer",
   "main": "dist",
   "scripts": {
-    "dev": "nodemon -w src --exec \"babel-node src --presets es2015,stage-0\"",
+    "dev": "DEBUG=express:* nodemon -L -w src --exec \"babel-node src --presets es2015,stage-0\"",
     "build": "babel src -s -D -d dist --presets es2015,stage-0",
     "start": "node dist",
     "prestart": "npm run -s build",
@@ -119,7 +119,8 @@
     "jsonfile": "^4.0.0",
     "morgan": "^1.8.0",
     "resource-router-middleware": "^0.6.0",
-    "shelljs": "^0.8.1"
+    "shelljs": "^0.8.1",
+    "write": "^1.0.3"
   },
   "devDependencies": {
     "babel-cli": "^6.9.0",

--- a/src/api/ec2.js
+++ b/src/api/ec2.js
@@ -1,8 +1,5 @@
 import {getUser, getInstances, cloneInstance} from './ec2/index';
 
-function workspaceDir(accessKeyId) {
-  return `/dd-master/${accessKeyId}`;
-}
 
 function creds(req, apiVersion) {
   return {
@@ -32,9 +29,10 @@ export function ec2Handler(router) {
   });
 
   router.post('/clone', (req, res) => {
+    req.connection.setTimeout( 1000 * 60 * 6 );
+
     const opts = {
       creds: creds(req, '2016-11-15'),
-      workspace: workspaceDir(req.body.accessKeyId),
       InstanceId: req.body.InstanceId,
       keyFile: req.files.keyFile,
       accessKeyId: req.body.accessKeyId,
@@ -45,7 +43,7 @@ export function ec2Handler(router) {
 
     cloneInstance(opts, err => {
       if (err) {
-        return res.status(err.code).send(err.message);
+        return res.status(404).send(err);
       }
 
       res.send('hello world');

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -1,3 +1,5 @@
+import {exec} from 'shelljs';
+
 const VERBOSE = 2;
 const DEBUG = VERBOSE >= 2;
 const INFO = VERBOSE >= 1;
@@ -41,3 +43,21 @@ export const logger = {
     }
   }
 };
+
+export function shell(command, cb) {
+  exec(command, {silent:true}, (code, stdout, stderr) => {
+    logger.info(command);
+    logger.debug(`stdout: ${stdout}`);
+    logger.debug(`stderr: ${stderr}`);
+
+    if (code !== 0) {
+      return cb({command, exitCode: code, stderr});
+    }
+
+    cb(null, stdout);
+  });
+}
+
+export function workspaceDir(accessKeyId) {
+  return `/dd-master/${accessKeyId}`;
+}


### PR DESCRIPTION
## Motivation
- Decided to use a separate VM to develop master
- `terraform init ...` returns error in the new VM dev box
- `strace -fe open,openat terraform init ...` pointed out that terraform looked for `~/.aws/credentials` file and failed to do so. The file is actually mentioned on terraform s3 backend docs but hardly noticeable. In order to fix this properly, the `-backend-config` flag is used when running terraform init command to point to the credentials file which should be automatically generated from credentials embedded in the request going into the master
- terraform may create files outside of a request's workspace so use terraform container for complete isolation
- Increase timeout for /clone endpoint

## Result
- Vagrantfile to automate VM setup
- add `-L` to nodemon to make it reload on file save inside VM
- refactor exec code for better logging
- chmod 400 keyfile before `terraform apply` and back to 664 after `terraform apply` to avoid permission denied and subsequent runs (go back to this later)
- use `accessKeyId` and `secretAccessKey` to generate `shared_credentials` and specify its path in `-backend-config` flag in the `terraform init ...` command
- run terraform commands in terraform container with request workspace mounted
- set connection timeout of req object going into /clone endpoint to 6 minutes

## Jira
https://issues.jboss.org/browse/FH-4800
https://issues.jboss.org/browse/FH-4807
https://issues.jboss.org/browse/FH-4808